### PR TITLE
feat: Added max_expected_flow_w configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,19 +77,20 @@ Else, if you prefer the graphical editor, use the menu to add the resource:
 
 #### Card options
 
-| Name               | Type      |   Default    | Description                                                                                                                                                                  |
-| ------------------ | --------- | :----------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| type               | `string`  | **required** | `custom:power-flow-card-plus`.                                                                                                                                                    |
-| entities           | `object`  | **required** | One or more sensor entities, see [entities object](#entities-object) for additional entity options.                                                                          |
-| title              | `string`  |              | Shows a title at the top of the card.                                                                                                                                        |
-| dashboard_link     | `string`  |              | Shows a link to an Energy Dashboard. Should be a url path to location of your choice. If you wanted to link to the built-in dashboard you would enter `/energy` for example. |
-| inverted_entities  | `string`  |              | Comma seperated list of entities that should be inverted (negative for consumption and positive for production). See [example usage](#inverted-entities-example).            |
-| kw_decimals        | `number`  |      1       | Number of decimals rounded to when kilowatts are displayed.                                                                                                                  |
-| w_decimals         | `number`  |      1       | Number of decimals rounded to when watts are displayed.                                                                                                                      |
-| min_flow_rate      | `number`  |     .75      | Represents the fastest amount of time in seconds for a flow dot to travel from one end to the other, see [flow formula](#flow-formula).                                      |
-| max_flow_rate      | `number`  |      6       | Represents the slowest amount of time in seconds for a flow dot to travel from one end to the other, see [flow formula](#flow-formula).                                      |
-| watt_threshold     | `number`  |      0       | The number of watts to display before converting to and displaying kilowatts. Setting of 0 will always display in kilowatts.                                                 |
-| clickable_entities | `boolean` |    false     | If true, clicking on the entity will open the entity's more info dialog.                                                                                                     |
+| Name                | Type      |   Default    | Description                                                                                                                                                                  |
+|---------------------| --------- |:------------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| type                | `string`  | **required** | `custom:power-flow-card-plus`.                                                                                                                                               |
+| entities            | `object`  | **required** | One or more sensor entities, see [entities object](#entities-object) for additional entity options.                                                                          |
+| title               | `string`  |              | Shows a title at the top of the card.                                                                                                                                        |
+| dashboard_link      | `string`  |              | Shows a link to an Energy Dashboard. Should be a url path to location of your choice. If you wanted to link to the built-in dashboard you would enter `/energy` for example. |
+| inverted_entities   | `string`  |              | Comma seperated list of entities that should be inverted (negative for consumption and positive for production). See [example usage](#inverted-entities-example).            |
+| kw_decimals         | `number`  |      1       | Number of decimals rounded to when kilowatts are displayed.                                                                                                                  |
+| w_decimals          | `number`  |      1       | Number of decimals rounded to when watts are displayed.                                                                                                                      |
+| min_flow_rate       | `number`  |     .75      | Represents the fastest amount of time in seconds for a flow dot to travel from one end to the other, see [flow formula](#flow-formula).                                      |
+| max_flow_rate       | `number`  |      6       | Represents the slowest amount of time in seconds for a flow dot to travel from one end to the other, see [flow formula](#flow-formula).                                      |
+| max_expected_flow_w | `number`  |    8000      | Represents the maximum amount of current expected to flow through the system at a given moment, see [flow formula](#flow-formula).                                           |
+| watt_threshold      | `number`  |      0       | The number of watts to display before converting to and displaying kilowatts. Setting of 0 will always display in kilowatts.                                                 |
+| clickable_entities  | `boolean` |    false     | If true, clicking on the entity will open the entity's more info dialog.                                                                                                     |
 
 #### Entities object
 
@@ -319,18 +320,25 @@ This should give you something like this:
 
 ### Flow Formula
 
-This formula is based on the offical formula used by the Energy Distribution card.
+This formula is based on the official formula used by the Energy Distribution card.
 
 ```js
 max - (value / totalLines) * (max - min);
 // max = max_flow_rate
 // min = min_flow_rate
 // value = line value, solar to grid for example
-// totalLines = gridConsumption + solarConsumption + solarToBattery +
-//   solarToGrid + batteryConsumption + batteryFromGrid + batteryToGrid
+// totalLines = Math.max(
+//     gridConsumption + solarConsumption + solarToBattery + solarToGrid + batteryConsumption + batteryFromGrid + batteryToGrid,
+//     config.max_expected_flow_w
+// )
 ```
 
-I'm not 100% happy with this. I'd prefer to see the dots travel slower when flow is low, but faster when flow is high. For example if the only flow is Grid to Home, I'd like to see the dot move faster if the flow is 15kW, but slower if it's only 2kW. Right now the speed would be the same. If you have a formula you'd like to propose please submit a PR.
+The previous version of this lacked the max_expected_flow_w configuration, so when the current across the entire system
+was low it would show animations as quickly as when the entire system running hot. This was because it was previously
+only relative to the current behaviour.
+
+The animation will not run any faster once this value has been exceeded, so you may wish to tweak max_expected_flow_w
+if you expect your system to have a higher total current than 8kw. 
 
 #### Credits
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Else, if you prefer the graphical editor, use the menu to add the resource:
 
 > ⚠️ This card offers a **LOT** of configuration options. Don't worry, if you want your card's appearance to match the oficial Energy Flow Card, you will only need to setup the entities. The rest of the options only enable further customization. If this is your goal, please go to [Minimal Configuration](#minimal-configuration)
 
-
 ### Options
 
 #### Card options
@@ -88,7 +87,7 @@ Else, if you prefer the graphical editor, use the menu to add the resource:
 | w_decimals          | `number`  |      1       | Number of decimals rounded to when watts are displayed.                                                                                                                      |
 | min_flow_rate       | `number`  |     .75      | Represents the fastest amount of time in seconds for a flow dot to travel from one end to the other, see [flow formula](#flow-formula).                                      |
 | max_flow_rate       | `number`  |      6       | Represents the slowest amount of time in seconds for a flow dot to travel from one end to the other, see [flow formula](#flow-formula).                                      |
-| max_expected_flow_w | `number`  |    8000      | Represents the maximum amount of current expected to flow through the system at a given moment, see [flow formula](#flow-formula).                                           |
+| max_expected_flow_w | `number`  |    8000      | Represents the maximum amount of power expected to flow through the system at a given moment, see [flow formula](#flow-formula).                                           |
 | watt_threshold      | `number`  |      0       | The number of watts to display before converting to and displaying kilowatts. Setting of 0 will always display in kilowatts.                                                 |
 | clickable_entities  | `boolean` |    false     | If true, clicking on the entity will open the entity's more info dialog.                                                                                                     |
 
@@ -333,12 +332,12 @@ max - (value / totalLines) * (max - min);
 // )
 ```
 
-The previous version of this lacked the max_expected_flow_w configuration, so when the current across the entire system
+The previous version of this lacked the max_expected_flow_w configuration, so when the power across the entire system
 was low it would show animations as quickly as when the entire system running hot. This was because it was previously
 only relative to the current behaviour.
 
 The animation will not run any faster once this value has been exceeded, so you may wish to tweak max_expected_flow_w
-if you expect your system to have a higher total current than 8kw. 
+if you expect your system to have a higher total power than 8kw.
 
 #### Credits
 

--- a/src/power-flow-card-plus-config.ts
+++ b/src/power-flow-card-plus-config.ts
@@ -50,6 +50,7 @@ export interface PowerFlowCardConfig extends LovelaceCardConfig {
   kw_decimals: number;
   min_flow_rate: number;
   max_flow_rate: number;
+  max_expected_flow_w: number;
   w_decimals: number;
   watt_threshold: number;
   clickable_entities: boolean;

--- a/src/power-flow-card-plus.ts
+++ b/src/power-flow-card-plus.ts
@@ -18,6 +18,7 @@ const KW_DECIMALS = 1;
 const MAX_FLOW_RATE = 6;
 const MIN_FLOW_RATE = 0.75;
 const W_DECIMALS = 1;
+const MAX_EXPECTED_FLOW_W = 8000;
 
 @customElement("power-flow-card-plus")
 export class PowerFlowCard extends LitElement {
@@ -50,6 +51,7 @@ export class PowerFlowCard extends LitElement {
       max_flow_rate: coerceNumber(config.max_flow_rate, MAX_FLOW_RATE),
       w_decimals: coerceNumber(config.w_decimals, W_DECIMALS),
       watt_threshold: coerceNumber(config.watt_threshold),
+      max_expected_flow_w: coerceNumber(config.max_expected_flow_w, MAX_EXPECTED_FLOW_W)
     };
   }
 
@@ -75,7 +77,7 @@ export class PowerFlowCard extends LitElement {
   private circleRate = (value: number, total: number): number => {
     const min = this._config?.min_flow_rate!;
     const max = this._config?.max_flow_rate!;
-    return max - (value / total) * (max - min);
+    return max - (value / Math.max(this._config?.max_expected_flow_w, total)) * (max - min);
   };
 
   private getEntityState = (entity: string | undefined): number => {
@@ -856,7 +858,7 @@ export class PowerFlowCard extends LitElement {
                                       : "1;0"
                                   }
                                   keyTimes="0;1"
-                                  
+
                                 >
                                   <mpath xlink:href="#individual1" />
                                 </animateMotion>
@@ -1224,7 +1226,7 @@ export class PowerFlowCard extends LitElement {
                           ? svg`<circle
                                 r="2.4"
                                 class="individual1"
-                                vector-effect="non-scaling-stroke"                              
+                                vector-effect="non-scaling-stroke"
                               >
                                 <animateMotion
                                   dur="1.66s"
@@ -1235,7 +1237,7 @@ export class PowerFlowCard extends LitElement {
                                       ? "0;1"
                                       : "1;0"
                                   }
-                                  keyTimes="0;1" 
+                                  keyTimes="0;1"
                                 >
                                   <mpath xlink:href="#individual1" />
                                 </animateMotion>

--- a/src/power-flow-card-plus.ts
+++ b/src/power-flow-card-plus.ts
@@ -18,7 +18,7 @@ const KW_DECIMALS = 1;
 const MAX_FLOW_RATE = 6;
 const MIN_FLOW_RATE = 0.75;
 const W_DECIMALS = 1;
-const MAX_EXPECTED_FLOW_W = 8000;
+const MAX_EXPECTED_FLOW_W = 5000;
 
 @customElement("power-flow-card-plus")
 export class PowerFlowCard extends LitElement {


### PR DESCRIPTION
The idea here is that that max_expected_flow_w config will set a hard minimum for the total value when calculating animations.

This should result in linearly slower animations under that value (but the current scaling when over).

Note that I wasn't entirely sure how to quickly test my changes, so they are just eyeballed for now. I figured it'd be worth raising the PR anyway, in case you wouldn't mind testing it. Otherwise it can stay stagnant until I confirm it actually works as expected.

The biggest assumption I've made is that `circleRate`'s `total` is in watts.

Also my IDE apparently cleaned up some trailing whitespace. I can revert this if you feel strongly about it.