### PR TITLE
feat: Added config options to show label when the grid is disconnected.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - Display Low Carbon Energy from the grid
 - Customize Low Carbon Energy label, icon, circle color, icon color and state type
 - Customize Battery, Solar and Home's color, icon, color of icon and label
+- Customize Grid Offline label
 
 ## Goal/Scope
 
@@ -122,6 +123,9 @@ At least one of _grid_, _battery_, or _solar_ is required. All entites (except _
 | color_circle | `boolean` or "production" or "consumption" | `false` | If set to `true`, the color of the grid circle changes depending on if you are consuming from the grid or returning to it. If set to `production`, circle color will match the production. If set to `consumption`, circle color will match the consumption. If set to `false`, circle color will match the consumption. |
 | secondary_info | `object` | `undefined` | Check [Secondary Info Object](#secondary-info-configuration) |
 | display_zero_tolerance | `number` | `0` | If the state of the entity is less than this number, it will be considered zero. This is to avoid having the grid circle show a small amount of consumption when the battery is trying to correct itself to the grid. |
+| offline_entity | `object` | `undefined` | Entity ID of a sensor providing grid-connection state. |
+| offline_value | `string` | `undefined` | Value of grid-connection sensor indicating the grid is offline. |
+| offline_label | `string` | `undefined` | Label to display when the grid is offline. If not specified, the actual sensor value is displayed. |
 
 #### Solar Configuration
 

--- a/src/power-flow-card-plus-config.ts
+++ b/src/power-flow-card-plus-config.ts
@@ -25,6 +25,9 @@ export interface PowerFlowCardPlusConfig extends LovelaceCardConfig {
       color_circle: boolean | "production" | "consumption";
       secondary_info?: SecondaryInfoType;
       display_zero_tolerance?: number;
+      offline_entity?: string;
+      offline_value?: string;
+      offline_label?: string;
     };
     solar?: {
       entity: string;

--- a/src/power-flow-card-plus.ts
+++ b/src/power-flow-card-plus.ts
@@ -950,6 +950,16 @@ class PowerFlowCardPlus extends LitElement {
                           <ha-icon class="small" .icon=${"mdi:arrow-right"}></ha-icon>${this.displayValue(totalFromGrid)}
                         </span>`
                       : ""}
+                    ${(entities.grid?.offline_entity != null && 
+                      entities.grid?.offline_value != null) &&
+                      ((typeof this.hass.states[entities.grid?.offline_entity] === 'number' && 
+                      this.hass.states[entities.grid?.offline_entity]?.state?.toString() === entities.grid?.offline_value) ||
+                      (this.hass.states[entities.grid?.offline_entity]?.state === entities.grid?.offline_value))
+                      ? html` <span class="offline">
+                          <ha-icon class="small" .icon=${"mdi:transmission-tower-off"}></ha-icon>
+                          ${entities.grid?.offline_label !== undefined ? entities.grid?.offline_label : this.hass.states[entities.grid?.offline_entity]?.state}
+                        </span>`
+                      : ""}
                   </div>
                   <span class="label">${entities.grid!.name || this.hass.localize("ui.panel.lovelace.cards.energy.energy_distribution.grid")}</span>
                 </div>`


### PR DESCRIPTION
Added three optional config options to the grid object to help detect when the grid is disconnected, and then either display the sensor value or a specified label.