### PR TITLE
Added functionality to have grid and battery display daily imported/exported power

### DIFF
--- a/src/power-flow-card-plus-config.ts
+++ b/src/power-flow-card-plus-config.ts
@@ -14,6 +14,8 @@ export interface PowerFlowCardPlusConfig extends LovelaceCardConfig {
       state_of_charge_unit_white_space?: boolean;
       color_state_of_charge_value?: boolean | "production" | "consumption";
       color_circle: boolean | "production" | "consumption";
+      energy_exported_info: SecondaryInfoType;
+      energy_imported_info: SecondaryInfoType;
     };
     grid?: {
       entity: string | ComboEntity;
@@ -25,6 +27,8 @@ export interface PowerFlowCardPlusConfig extends LovelaceCardConfig {
       color_circle: boolean | "production" | "consumption";
       secondary_info?: SecondaryInfoType;
       display_zero_tolerance?: number;
+      energy_exported_info: SecondaryInfoType;
+      energy_imported_info: SecondaryInfoType;
     };
     solar?: {
       entity: string;


### PR DESCRIPTION
Hey there,

as I mentioned, I started implementing an option to add daily imported and exported power to the grid and battery circles.

I added two new configuration options to grid and battery: energy_exported_info and energy_imported_info

Configuration can look like this:

```
type: custom:power-flow-card-plus
entities:
  home:
    color_icon: true
    secondary_info:
      entity: sensor.solar_house_consumption_daily
      unit_of_measurement: kWh
  grid:
    entity:
      consumption: sensor.solar_grid_to_house_w
      production: sensor.solar_panel_to_grid_w
    display_state: one_way
    color_icon: true
    energy_exported_info:
      entity: sensor.solar_exported_power_daily
      unit_of_measurement: kWh
    energy_imported_info:
      entity: sensor.solar_imported_power_daily
      unit_of_measurement: kWh
  solar:
    entity: sensor.solar_panel_production_w
    color_icon: true
    secondary_info:
      entity: sensor.solar_panel_production_daily
      unit_of_measurement: kWh
  battery:
    entity:
      consumption: sensor.solar_battery_to_house_w
      production: sensor.solar_battery_in_w
    state_of_charge: sensor.solaredge_b1_state_of_energy
    display_state: one_way
    color_icon: true
    color:
      production: '#fc888b'
    energy_exported_info:
      entity: sensor.solar_battery_out_daily
      unit_of_measurement: kWh
    energy_imported_info:
      entity: sensor.solar_battery_in_daily
      unit_of_measurement: kWh
```

This will produce something like can be seen in the following screenshot:

![image](https://user-images.githubusercontent.com/37976738/233658103-101795d6-617c-4e23-a68e-d687a77de5ea.png)

If used, the grid and battery icons will be moved over to the side and a smaller size is used.

This will, because of size issues, only work when using "one_way".

Coloring is not yet possible. I could implement that in the future. Styling/CSS is also not perfect yet. But this is a good start. 

Let me know what you think.