### PR TITLE
Fixed bug solar to battery line not showing

### DIFF
--- a/src/power-flow-card-plus.ts
+++ b/src/power-flow-card-plus.ts
@@ -566,8 +566,8 @@ export class PowerFlowCardPlus extends LitElement {
         }
       }
       solar.state.toHome = 0;
-    } else if (battery.state.toBattery && battery.state.toBattery > 0) {
-      grid.state.toBattery = battery.state.toBattery;
+    } else {
+      grid.state.toBattery = 0;
     }
     grid.state.toBattery = (grid.state.toBattery ?? 0) > largestGridBatteryTolerance ? grid.state.toBattery : 0;
 


### PR DESCRIPTION
`grid.state.toBattery` was equal to `battery.state.toBattery` when `solar.state.toHome` was positive, so it was assuming all charge comming from grid and not from solar.