### PR TITLE
fix: transpile node_modules to support older ios devices

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,3 @@
 module.exports = {
-  presets: [
-    ['@babel/preset-env', { targets: { node: 'current' } }],
-    '@babel/preset-typescript',
-  ],
+  presets: [["@babel/preset-env", { targets: { node: "current", ios: "12" } }], "@babel/preset-typescript"],
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,9 +3,9 @@ import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import serve from "rollup-plugin-serve";
-import terser  from "@rollup/plugin-terser";
+import terser from "@rollup/plugin-terser";
 import typescript from "@rollup/plugin-typescript";
-import minifyHTML from 'rollup-plugin-minify-html-literals';
+import minifyHTML from "rollup-plugin-minify-html-literals";
 
 const dev = process.env.ROLLUP_WATCH;
 
@@ -41,7 +41,7 @@ export default [
       }),
       commonjs(),
       babel({
-        exclude: "node_modules/**",
+        exclude: /node_modules\/(?!superstruct)\/.*/,
         babelHelpers: "bundled",
       }),
       ...(dev ? [serve(serveOptions)] : [terser()]),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,7 +26,7 @@ export default [
       {
         dir: "dist",
         format: "es",
-        inlineDynamicImports: true,
+        inlineDynamicImports: false,
       },
     ],
     plugins: [
@@ -41,10 +41,11 @@ export default [
       }),
       commonjs(),
       babel({
-        exclude: /node_modules\/(?!superstruct)\/.*/,
+        exclude: "node_modules/**",
         babelHelpers: "bundled",
       }),
       ...(dev ? [serve(serveOptions)] : [terser()]),
+      ...(dev ? [serve(serveOptions)] : []),
     ],
     moduleContext: (id) => {
       const thisAsWindowForModules = [


### PR DESCRIPTION
Fixes #414 (and maybe #77 and #150) by transpiling the `superstruct` library - please can you give this a test as it seems to be very eager to transpile everything in node_modules