### PR TITLE
Allowing piping for numeric entity states

### DIFF
--- a/src/states/raw/base.ts
+++ b/src/states/raw/base.ts
@@ -1,19 +1,18 @@
 import { HomeAssistant } from "custom-card-helpers";
-import { IndividualField, PowerFlowCardPlusConfig } from "../../power-flow-card-plus-config";
-import { EntityType, IndividualDeviceType } from "../../type";
+import { PowerFlowCardPlusConfig } from "../../power-flow-card-plus-config";
+import { EntityType } from "../../type";
 import { isNumberValue } from "../../utils/utils";
 import { isEntityInverted } from "../utils/isEntityInverted";
 import { onlyNegative, onlyPositive } from "../utils/negativePositive";
 import { getEntityStateWatts } from "../utils/getEntityStateWatts";
-import { getEntityNames } from "../utils/mutliEntity";
+import { getFirstEntityName } from "../utils/mutliEntity";
 
 export const getSecondaryState = (hass: HomeAssistant, config: PowerFlowCardPlusConfig, field: EntityType) => {
   const entity = config.entities?.[field]?.secondary_info?.entity;
 
   if (typeof entity !== "string") return null;
 
-  const ids = getEntityNames(entity);
-  const entityObj = hass.states[ids[0]];
+  const entityObj = hass.states[getFirstEntityName(entity)];
   const secondaryState = entityObj.state;
 
   if (isNumberValue(secondaryState)) return Number(secondaryState);

--- a/src/states/raw/base.ts
+++ b/src/states/raw/base.ts
@@ -5,13 +5,15 @@ import { isNumberValue } from "../../utils/utils";
 import { isEntityInverted } from "../utils/isEntityInverted";
 import { onlyNegative, onlyPositive } from "../utils/negativePositive";
 import { getEntityStateWatts } from "../utils/getEntityStateWatts";
+import { getEntityNames } from "../utils/mutliEntity";
 
 export const getSecondaryState = (hass: HomeAssistant, config: PowerFlowCardPlusConfig, field: EntityType) => {
   const entity = config.entities?.[field]?.secondary_info?.entity;
 
   if (typeof entity !== "string") return null;
 
-  const entityObj = hass.states[entity];
+  const ids = getEntityNames(entity);
+  const entityObj = hass.states[ids[0]];
   const secondaryState = entityObj.state;
 
   if (isNumberValue(secondaryState)) return Number(secondaryState);

--- a/src/states/utils/existenceEntity.ts
+++ b/src/states/utils/existenceEntity.ts
@@ -3,28 +3,25 @@ import { isNumberValue } from "../../utils/utils";
 import { getEntityNames } from "./mutliEntity";
 
 export const isEntityAvailable = (hass: HomeAssistant, entityId: string): boolean => {
-    const ids = getEntityNames(entityId);
-    for (const id of ids) {
-        if (!isNumberValue(hass.states[id]?.state)) {
-            // if one does not exist, the whole result should be false
-            return false;
-        }
+  const ids = getEntityNames(entityId);
+  for (const id of ids) {
+    if (!isNumberValue(hass.states[id]?.state)) {
+      // if one does not exist, the whole result should be false
+      return false;
     }
+  }
 
-    // if we have multiple IDs, we can safely return true here.
-    return ids.length > 0;
-}
+  // if we have multiple IDs, we can safely return true here.
+  return ids.length > 0;
+};
 
 export const doesEntityExist = (hass: HomeAssistant, entityId: string): boolean => {
-
-    const ids = getEntityNames(entityId);
-    for (const id of ids) {
-        if (!(id in hass.states)) {
-            return false;
-        }
+  const ids = getEntityNames(entityId);
+  for (const id of ids) {
+    if (!(id in hass.states)) {
+      return false;
     }
+  }
 
-    return true;
-}
-
-
+  return true;
+};

--- a/src/states/utils/existenceEntity.ts
+++ b/src/states/utils/existenceEntity.ts
@@ -1,6 +1,30 @@
 import { HomeAssistant } from "custom-card-helpers";
 import { isNumberValue } from "../../utils/utils";
+import { getEntityNames } from "./mutliEntity";
 
-export const isEntityAvailable = (hass: HomeAssistant, entityId: string): boolean => isNumberValue(hass.states[entityId]?.state);
+export const isEntityAvailable = (hass: HomeAssistant, entityId: string): boolean => {
+    const ids = getEntityNames(entityId);
+    for (const id of ids) {
+        if (!isNumberValue(hass.states[id]?.state)) {
+            // if one does not exist, the whole result should be false
+            return false;
+        }
+    }
 
-export const doesEntityExist = (hass: HomeAssistant, entityId: string): boolean => entityId in hass.states;
+    // if we have multiple IDs, we can safely return true here.
+    return ids.length > 0;
+}
+
+export const doesEntityExist = (hass: HomeAssistant, entityId: string): boolean => {
+
+    const ids = getEntityNames(entityId);
+    for (const id of ids) {
+        if (!(id in hass.states)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+

--- a/src/states/utils/getEntityState.ts
+++ b/src/states/utils/getEntityState.ts
@@ -2,11 +2,23 @@ import { HomeAssistant } from "custom-card-helpers";
 import { isEntityAvailable } from "./existenceEntity";
 import { unavailableOrMisconfiguredError } from "../../utils/unavailableError";
 import { coerceNumber } from "../../utils/utils";
+import { getEntityNames } from "./mutliEntity";
 
 export const getEntityState = (hass: HomeAssistant, entity: string | undefined): number | null => {
   if (!entity || !isEntityAvailable(hass, entity)) {
     unavailableOrMisconfiguredError(entity);
     return null;
   }
-  return coerceNumber(hass.states[entity].state);
+
+  const ids = getEntityNames(entity);
+
+  let endResult: number = 0;
+  let tempNumber: number;
+  for (const id of ids) {
+    tempNumber = coerceNumber(hass.states[id].state);
+    // somehow using += does not work here (maybe something with rollup?)
+    endResult = endResult + tempNumber;
+  }
+
+  return endResult;
 };

--- a/src/states/utils/getEntityStateObj.ts
+++ b/src/states/utils/getEntityStateObj.ts
@@ -2,7 +2,7 @@ import { HassEntity } from "home-assistant-js-websocket";
 import { isEntityAvailable } from "./existenceEntity";
 import { unavailableOrMisconfiguredError } from "../../utils/unavailableError";
 import { HomeAssistant } from "custom-card-helpers";
-import { getEntityNames } from "./mutliEntity";
+import { getFirstEntityName } from "./mutliEntity";
 
 export const getEntityStateObj = (hass: HomeAssistant, entity: string | undefined): HassEntity | undefined => {
   if (!entity || !isEntityAvailable(hass, entity)) {
@@ -10,6 +10,5 @@ export const getEntityStateObj = (hass: HomeAssistant, entity: string | undefine
     return undefined;
   }
 
-  const ids = getEntityNames(entity);
-  return hass.states[ids[0]];
+  return hass.states[getFirstEntityName(entity)];
 };

--- a/src/states/utils/getEntityStateObj.ts
+++ b/src/states/utils/getEntityStateObj.ts
@@ -2,11 +2,14 @@ import { HassEntity } from "home-assistant-js-websocket";
 import { isEntityAvailable } from "./existenceEntity";
 import { unavailableOrMisconfiguredError } from "../../utils/unavailableError";
 import { HomeAssistant } from "custom-card-helpers";
+import { getEntityNames } from "./mutliEntity";
 
 export const getEntityStateObj = (hass: HomeAssistant, entity: string | undefined): HassEntity | undefined => {
   if (!entity || !isEntityAvailable(hass, entity)) {
     unavailableOrMisconfiguredError(entity);
     return undefined;
   }
-  return hass.states[entity];
+
+  const ids = getEntityNames(entity);
+  return hass.states[ids[0]];
 };

--- a/src/states/utils/getEntityStateWatts.ts
+++ b/src/states/utils/getEntityStateWatts.ts
@@ -1,13 +1,15 @@
 import { HomeAssistant } from "custom-card-helpers";
 import { getEntityState } from "./getEntityState";
+import { getEntityNames } from "./mutliEntity";
 
 const prefixes = ["K", "M", "G", "T", "P", "E", "Z", "Y"];
 
 export const getEntityStateWatts = (hass: HomeAssistant, entity: string | undefined): number => {
   const state = getEntityState(hass, entity);
   if (!entity || state === null) return 0;
+  const ids = getEntityNames(entity);
 
-  const unit = hass.states[entity].attributes.unit_of_measurement ?? "";
+  const unit = hass.states[ids[0]].attributes.unit_of_measurement ?? "";
 
   return convertUnitToWatts(state, unit);
 };

--- a/src/states/utils/getEntityStateWatts.ts
+++ b/src/states/utils/getEntityStateWatts.ts
@@ -1,15 +1,14 @@
 import { HomeAssistant } from "custom-card-helpers";
 import { getEntityState } from "./getEntityState";
-import { getEntityNames } from "./mutliEntity";
+import { getFirstEntityName } from "./mutliEntity";
 
 const prefixes = ["K", "M", "G", "T", "P", "E", "Z", "Y"];
 
 export const getEntityStateWatts = (hass: HomeAssistant, entity: string | undefined): number => {
   const state = getEntityState(hass, entity);
   if (!entity || state === null) return 0;
-  const ids = getEntityNames(entity);
 
-  const unit = hass.states[ids[0]].attributes.unit_of_measurement ?? "";
+  const unit = hass.states[getFirstEntityName(entity)].attributes.unit_of_measurement ?? "";
 
   return convertUnitToWatts(state, unit);
 };

--- a/src/states/utils/mutliEntity.ts
+++ b/src/states/utils/mutliEntity.ts
@@ -1,3 +1,9 @@
-export const getEntityNames = (name: string): string[] => {
-    return name?.split("|").map(p => p.trim());
+export const getEntityNames = (entities: string): string[] => {
+    return entities?.split("|").map(p => p.trim());
+}
+
+export const getFirstEntityName = (entities: string): string => {
+    const names = getEntityNames(entities);
+
+    return names.length > 0 ? names[0] : "";
 }

--- a/src/states/utils/mutliEntity.ts
+++ b/src/states/utils/mutliEntity.ts
@@ -1,9 +1,9 @@
 export const getEntityNames = (entities: string): string[] => {
-    return entities?.split("|").map(p => p.trim());
-}
+  return entities?.split("|").map((p) => p.trim());
+};
 
 export const getFirstEntityName = (entities: string): string => {
-    const names = getEntityNames(entities);
+  const names = getEntityNames(entities);
 
-    return names.length > 0 ? names[0] : "";
-}
+  return names.length > 0 ? names[0] : "";
+};

--- a/src/states/utils/mutliEntity.ts
+++ b/src/states/utils/mutliEntity.ts
@@ -1,0 +1,3 @@
+export const getEntityNames = (name: string): string[] => {
+    return name?.split("|").map(p => p.trim());
+}

--- a/src/utils/get-default-config.ts
+++ b/src/utils/get-default-config.ts
@@ -1,6 +1,7 @@
 /* eslint-disable import/extensions */
 import { HomeAssistant } from "custom-card-helpers";
 import { DisplayZeroLinesMode } from "../power-flow-card-plus-config";
+import { getFirstEntityName } from "../states/utils/mutliEntity";
 
 export const defaultValues = {
   maxFlowRate: 6,
@@ -20,11 +21,12 @@ export const defaultValues = {
 
 export function getDefaultConfig(hass: HomeAssistant): object {
   function checkStrings(entiyId: string, testStrings: string[]): boolean {
-    const friendlyName = hass.states[entiyId].attributes.friendly_name;
-    return testStrings.some((str) => entiyId.includes(str) || friendlyName?.includes(str));
+    const firstId = getFirstEntityName(entiyId)
+    const friendlyName = hass.states[firstId].attributes.friendly_name;
+    return testStrings.some((str) => firstId.includes(str) || friendlyName?.includes(str));
   }
   const powerEntities = Object.keys(hass.states).filter((entityId) => {
-    const stateObj = hass.states[entityId];
+    const stateObj = hass.states[getFirstEntityName(entityId)];
     const isAvailable =
       (stateObj.state && stateObj.attributes && stateObj.attributes.device_class === "power") || stateObj.entity_id.includes("power");
     return isAvailable;

--- a/src/utils/get-default-config.ts
+++ b/src/utils/get-default-config.ts
@@ -21,7 +21,7 @@ export const defaultValues = {
 
 export function getDefaultConfig(hass: HomeAssistant): object {
   function checkStrings(entiyId: string, testStrings: string[]): boolean {
-    const firstId = getFirstEntityName(entiyId)
+    const firstId = getFirstEntityName(entiyId);
     const friendlyName = hass.states[firstId].attributes.friendly_name;
     return testStrings.some((str) => firstId.includes(str) || friendlyName?.includes(str));
   }


### PR DESCRIPTION
State values of entities can now be merged together by piping the entity names. Only works with numbers. If the state is not a number, the first will be used. If another property than "state" is used, only the values of the first entity will be used.

E.g. my inverter does not provide a single sensor for the current grid consumption. Instead each phase has its own value. So I made a small modification to your project by allowing piping sensor entities. 

Example:
  grid:
    entity: >-
      sensor.foxessrs485_grid_ct_r | sensor.foxessrs485_grid_ct_s |
      sensor.foxessrs485_grid_ct_t
