### PR TITLE
Show flow from grid to battery

### DIFF
--- a/src/power-flow-card-plus.ts
+++ b/src/power-flow-card-plus.ts
@@ -363,8 +363,10 @@ export class PowerFlowCardPlus extends LitElement {
         }
       }
       solar.state.toHome = 0;
-    } else {
+    } else if (solar.state.toHome !== null && solar.state.toHome > 0) {
       grid.state.toBattery = 0;
+    } else if (battery.state.toBattery && battery.state.toBattery > 0) {
+      grid.state.toBattery = battery.state.toBattery;
     }
     grid.state.toBattery = (grid.state.toBattery ?? 0) > largestGridBatteryTolerance ? grid.state.toBattery : 0;
 


### PR DESCRIPTION
Show power flowing from grid to battery when solar power is zero or if it is unavailable.

Earlier this flow was working, but after [this commit](https://github.com/flixlix/power-flow-card-plus/commit/4e560fb06d091402c12041d6cd3d9a5dbc075b5e#diff-c9d15805528c6a512336660846b3db265ff419fc4b6f42000047b3580d140b56L569) it broke.

The fix in the commit did not check for the case where there was no solar power which I hopefully(!) handled correctly.

fixes #599
fixes #472