### PR TITLE
fix: conditionally render battery-to-grid circle based on config

### DIFF
--- a/src/components/flows/batteryGrid.ts
+++ b/src/components/flows/batteryGrid.ts
@@ -41,7 +41,7 @@ export const flowBatteryGrid = (config: PowerFlowCardPlusConfig, { battery, grid
           </animateMotion>
         </circle>`
             : ""}
-          ${battery.state.toGrid
+          ${checkShouldShowDots(config) && battery.state.toGrid
             ? svg`<circle
               r="1"
               class="battery-to-grid"


### PR DESCRIPTION
closes #773 