### PR TITLE
Use production color when no consumption or production on the grid

### DIFF
--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -41,7 +41,7 @@ export const gridElement = (
       ${(entities.grid?.display_state === "two_way" ||
         entities.grid?.display_state === undefined ||
         (entities.grid?.display_state === "one_way_no_zero" && (grid.state.toGrid ?? 0) > 0) ||
-        (entities.grid?.display_state === "one_way" && (grid.state.fromGrid === null || grid.state.fromGrid === 0) && grid.state.toGrid !== 0)) &&
+        (entities.grid?.display_state === "one_way" && ((grid.state.fromGrid ?? 0) == 0))) &&
       grid.state.toGrid !== null &&
       !grid.powerOutage.isOutage
         ? html`<span
@@ -70,7 +70,7 @@ export const gridElement = (
       ${((entities.grid?.display_state === "two_way" ||
         entities.grid?.display_state === undefined ||
         (entities.grid?.display_state === "one_way_no_zero" && grid.state.fromGrid > 0) ||
-        (entities.grid?.display_state === "one_way" && (grid.state.toGrid === null || grid.state.toGrid === 0))) &&
+        (entities.grid?.display_state === "one_way" && (grid.state.toGrid ?? 0) == 0 && grid.state.fromGrid > 0)) &&
         grid.state.fromGrid !== null &&
         !grid.powerOutage.isOutage) ||
       (grid.powerOutage.isOutage && !!grid.powerOutage.entityGenerator)

--- a/src/style/all.ts
+++ b/src/style/all.ts
@@ -35,7 +35,7 @@ export const allDynamicStyles = (
       : grid.color.icon_type === "production"
       ? "var(--energy-grid-return-color)"
       : grid.color.icon_type === true
-      ? (grid.state.fromGrid ?? 0) >= (grid.state.toGrid ?? 0)
+      ? (grid.state.fromGrid ?? 0) > (grid.state.toGrid ?? 0)
         ? "var(--energy-grid-consumption-color)"
         : "var(--energy-grid-return-color)"
       : "var(--primary-text-color)"
@@ -48,7 +48,7 @@ export const allDynamicStyles = (
       : grid.color.circle_type === "production"
       ? "var(--energy-grid-return-color)"
       : grid.color.circle_type === true
-      ? (grid.state.fromGrid ?? 0) >= (grid.state.toGrid ?? 0)
+      ? (grid.state.fromGrid ?? 0) > (grid.state.toGrid ?? 0)
         ? "var(--energy-grid-consumption-color)"
         : "var(--energy-grid-return-color)"
       : "var(--energy-grid-consumption-color)"


### PR DESCRIPTION
I wanted my grid circle/icon to be green when there was no consumption or production. I think it about the same for flixlix/flixlix-cards#171
So instead of creating an issue, i just looked into the code to see if I could make the changes. So hence, this PR.


Old:
![image](https://github.com/user-attachments/assets/9723d1f8-eda0-43a2-8611-301e6e5b75b1)

New:
![image](https://github.com/user-attachments/assets/4cd6b833-5980-4e8c-8d7e-ce0cf0943bb2)

