### PR TITLE
fix: 🐛 more than four individuals causing colors to be incorrect

### DIFF
--- a/src/power-flow-card-plus.ts
+++ b/src/power-flow-card-plus.ts
@@ -516,6 +516,13 @@ export class PowerFlowCardPlus extends LitElement {
       });
     };
 
+    const sortedIndividualObjects = this._config.sort_individual_devices ? sortIndividualObjects(individualObjs) : individualObjs;
+
+    const individualFieldLeftTop = getTopLeftIndividual(sortedIndividualObjects);
+    const individualFieldLeftBottom = getBottomLeftIndividual(sortedIndividualObjects);
+    const individualFieldRightTop = getTopRightIndividual(sortedIndividualObjects);
+    const individualFieldRightBottom = getBottomRightIndividual(sortedIndividualObjects);
+
     const individualKeys = ["left-top", "left-bottom", "right-top", "right-bottom"];
     // Templates
     const templatesObj: TemplatesObj = {
@@ -538,17 +545,10 @@ export class PowerFlowCardPlus extends LitElement {
       entities,
       homeLargestSource,
       homeSources,
-      individual: individualObjs,
+      individual: sortedIndividualObjects,
       nonFossil,
       isCardWideEnough,
     });
-
-    const sortedIndividualObjects = this._config.sort_individual_devices ? sortIndividualObjects(individualObjs) : individualObjs;
-
-    const individualFieldLeftTop = getTopLeftIndividual(sortedIndividualObjects);
-    const individualFieldLeftBottom = getBottomLeftIndividual(sortedIndividualObjects);
-    const individualFieldRightTop = getTopRightIndividual(sortedIndividualObjects);
-    const individualFieldRightBottom = getBottomRightIndividual(sortedIndividualObjects);
 
     return html`
       <ha-card

--- a/src/states/raw/individual/getIndividualObject.ts
+++ b/src/states/raw/individual/getIndividualObject.ts
@@ -3,6 +3,7 @@ import { IndividualDeviceType } from "@/type";
 import { computeFieldIcon, computeFieldName } from "@/utils/computeFieldAttributes";
 import { getIndividualSecondaryState, getIndividualState } from ".";
 import { hasIndividualObject } from "./hasIndividualObject";
+import {convertColorListToHex} from "../../../utils/convertColor";
 
 const fallbackIndividualObject: IndividualObject = {
   field: undefined,
@@ -74,7 +75,14 @@ export const getIndividualObject = (hass: HomeAssistant, field: IndividualDevice
   const isStateNegative = state && state < 0;
   const userConfiguredInvertAnimation = field?.inverted_animation || false;
   const invertAnimation = isStateNegative ? !userConfiguredInvertAnimation : userConfiguredInvertAnimation;
-  const color = field?.color && typeof field?.color === "string" ? field?.color : null;
+  let colorConv;
+  if (field?.color && typeof field?.color === "string") {
+    colorConv = field.color;
+  }
+  else if (field?.color && typeof field?.color === "object") {
+      colorConv = convertColorListToHex(field.color);
+  }
+  const color = colorConv ? colorConv : null;
 
   return {
     field,

--- a/src/style/all.ts
+++ b/src/style/all.ts
@@ -250,11 +250,8 @@ export const allDynamicStyles = (
       );
     };
 
-    let individualIndex = 0;
-    individual.forEach((_, index) => {
-      if (!individual[index].has) return;
-      getStylesForIndividual(entities!.individual![index], individualIndex);
-      individualIndex++;
-    });
+    for (let index = 0; index < (individual.length < 4 ? individual.length : 4); index++){
+      getStylesForIndividual(individual![index], index);
+    };
   }
 };


### PR DESCRIPTION
individual data structure had two color fields in it, and object colors, such as the UI config gerjneates, were not being moved from one to the other so they were missed.  The list of entities passed to the style function to generate the CSS colors for the individual entities was not sorted first, so when that option was selected the wrong entities would be used for color selection.  That function was also processing the entire list of individual entities when only up to four are needed.

TypeScript is new to me and I am also rather rusty in general, so review of this would be appreciated.