### PR TITLE
Make round function output the requested number of decimals

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-redeclare */
-export const round = (value: number, decimalPlaces: number): number => Number(`${Math.round(Number(`${value}e${decimalPlaces}`))}e-${decimalPlaces}`);
+export const round = (value: number, decimalPlaces: number): number => Number(value).toFixed(decimalPlaces);
 
 /**
  * @license


### PR DESCRIPTION
Thanks for the great card!

I was triggert by a monetary value being rounded to a single decimal while I configured 2.
![image](https://github.com/user-attachments/assets/d6d71f67-2682-4a0f-986e-69de04733ec1)

I'm not a TypeScript expert, nor did I test this in all possible variations, so handle with care :wink: 
But this patch seems to do the trick.

![image](https://github.com/user-attachments/assets/e79c80df-6380-49cc-9ab1-ebeb1f19fd4f)
