### PR TITLE
fix: wrong secondary template if more than 4 individual entities

### DIFF
--- a/src/power-flow-card-plus.ts
+++ b/src/power-flow-card-plus.ts
@@ -516,7 +516,6 @@ export class PowerFlowCardPlus extends LitElement {
       });
     };
 
-    const individualKeys = ["left-top", "left-bottom", "right-top", "right-bottom"];
     // Templates
     const templatesObj: TemplatesObj = {
       gridSecondary: this._templateResults.gridSecondary?.result,
@@ -524,7 +523,7 @@ export class PowerFlowCardPlus extends LitElement {
       homeSecondary: this._templateResults.homeSecondary?.result,
 
       nonFossilFuelSecondary: this._templateResults.nonFossilFuelSecondary?.result,
-      individual: individualObjs?.map((_, index) => this._templateResults[`${individualKeys[index]}Secondary`]?.result) || [],
+      individual: individualObjs?.map((_, index) => this._templateResults[`individual${index}Secondary`]?.result) || [],
     };
 
     // Styles
@@ -689,9 +688,8 @@ export class PowerFlowCardPlus extends LitElement {
     for (const [key, value] of Object.entries(templatesObj)) {
       if (value) {
         if (Array.isArray(value)) {
-          const individualKeys = ["left-top", "left-bottom", "right-top", "right-bottom"];
           value.forEach((template, index) => {
-            if (template) this._tryConnect(template, `${individualKeys[index]}Secondary`);
+            if (template) this._tryConnect(template, `individual${index}Secondary`);
           });
         } else {
           this._tryConnect(value, key);


### PR DESCRIPTION
In case you have more than 4 individual entries defined of which some of them are currently invisible (due to them being zero for example), the wrong template gets rendered for the secondary information.