### PR TITLE
Updated nonFossil code to remove redundancy and add Invert State mode

### DIFF
--- a/src/components/nonFossil.ts
+++ b/src/components/nonFossil.ts
@@ -22,7 +22,7 @@ export const nonFossilElement = (
   config: PowerFlowCardPlusConfig,
   { nonFossil, entities, templatesObj, grid, newDur }: NonFossil
 ) => {
-  return html`${!nonFossil.hasPercentage
+  return html`${!nonFossil.has
     ? html`<div class="spacer"></div>`
     : html`<div class="circle-container low-carbon">
         <span class="label">${nonFossil.name}</span>

--- a/src/power-flow-card-plus.ts
+++ b/src/power-flow-card-plus.ts
@@ -20,7 +20,7 @@ import { getBatteryInState, getBatteryOutState, getBatteryStateOfCharge } from "
 import { getGridConsumptionState, getGridProductionState, getGridSecondaryState } from "./states/raw/grid";
 import { getHomeSecondaryState } from "./states/raw/home";
 import { getIndividualObject, IndividualObject } from "./states/raw/individual/getIndividualObject";
-import { getNonFossilHas, getNonFossilHasPercentage, getNonFossilSecondaryState } from "./states/raw/nonFossil";
+import { getNonFossilHas, getNonFossilSecondaryState, getNonFossilState } from "./states/raw/nonFossil";
 import { getSolarSecondaryState, getSolarState } from "./states/raw/solar";
 import { adjustZeroTolerance } from "./states/tolerance/base";
 import { doesEntityExist } from "./states/utils/existenceEntity";
@@ -299,7 +299,6 @@ export class PowerFlowCardPlus extends LitElement {
       name: computeFieldName(this.hass, entities.fossil_fuel_percentage, this.hass.localize("card.label.non_fossil_fuel_percentage")),
       icon: computeFieldIcon(this.hass, entities.fossil_fuel_percentage, "mdi:leaf"),
       has: getNonFossilHas(this.hass, this._config),
-      hasPercentage: getNonFossilHasPercentage(this.hass, this._config),
       state: {
         power: initialNumericState,
       },
@@ -404,13 +403,11 @@ export class PowerFlowCardPlus extends LitElement {
       solar.state.toGrid = 0;
       grid.icon = grid.powerOutage.icon;
       nonFossil.has = false;
-      nonFossil.hasPercentage = false;
     }
 
     // Set Initial State for Non Fossil Fuel Percentage
     if (nonFossil.has) {
-      const nonFossilFuelDecimal = 1 - (getEntityState(this.hass, entities.fossil_fuel_percentage?.entity) ?? 0) / 100;
-      nonFossil.state.power = grid.state.toHome * nonFossilFuelDecimal;
+      nonFossil.state.power = getNonFossilState(this.hass, this._config) ?? 0;
     }
 
     // Calculate Individual Consumption, ignore not shown objects
@@ -582,7 +579,7 @@ export class PowerFlowCardPlus extends LitElement {
           id="power-flow-card-plus"
           style=${this._config.style_card_content ? this._config.style_card_content : ""}
         >
-          ${solar.has || individualObjs?.some((individual) => individual?.has) || nonFossil.hasPercentage
+          ${solar.has || individualObjs?.some((individual) => individual?.has) || nonFossil.has
             ? html`<div class="row">
                 ${nonFossilElement(this, this._config, {
                   entities,

--- a/src/states/raw/nonFossil.ts
+++ b/src/states/raw/nonFossil.ts
@@ -3,39 +3,30 @@ import { PowerFlowCardPlusConfig } from "@/power-flow-card-plus-config";
 import { getGridConsumptionState } from "./grid";
 import { getEntityState } from "@/states/utils/getEntityState";
 import { getSecondaryState } from "./base";
+import { isEntityInverted } from "../utils/isEntityInverted";
+import { adjustZeroTolerance } from "../tolerance/base";
 
 export const getNonFossilHas = (hass: HomeAssistant, config: PowerFlowCardPlusConfig) => {
   const nonFossil = config.entities.fossil_fuel_percentage;
   const grid = config.entities.grid;
   const fossilPercentageEntity = nonFossil?.entity;
   const fossilPercentageDisplayZero = nonFossil?.display_zero;
-  const gridFromGrid = getGridConsumptionState(hass, config);
+  const rawPowerFromGrid = getGridConsumptionState(hass, config);
+  const powerFromGrid = adjustZeroTolerance(rawPowerFromGrid, grid?.display_zero_tolerance);
 
   if (fossilPercentageEntity === undefined) return false;
 
   if (fossilPercentageDisplayZero === true) return true;
 
-  if (gridFromGrid === null) return false;
+  if (powerFromGrid === null || powerFromGrid === 0) return false;
 
-  return gridFromGrid * 1 - (getEntityState(hass, fossilPercentageEntity) ?? 0) / 100 > 0;
-};
+  const nonFossilDecimal = isEntityInverted(config, "fossil_fuel_percentage")
+    ? (getEntityState(hass, fossilPercentageEntity) ?? 0) / 100
+    : 1 - (getEntityState(hass, fossilPercentageEntity) ?? 0) / 100;
+  const has = powerFromGrid * nonFossilDecimal > 0;
 
-export const getNonFossilHasPercentage = (hass: HomeAssistant, config: PowerFlowCardPlusConfig) => {
-  const nonFossil = config.entities.fossil_fuel_percentage;
-  const grid = config.entities.grid;
-  const fossilPercentageEntity = nonFossil?.entity;
-  const fossilPercentageDisplayZero = nonFossil?.display_zero;
-  const gridFromGrid = getGridConsumptionState(hass, config);
 
-  if (fossilPercentageEntity === undefined) return false;
-
-  if (fossilPercentageDisplayZero === true) return true;
-
-  if (gridFromGrid === null) return false;
-
-  if (getNonFossilHas(hass, config) === false) return false;
-
-  return gridFromGrid * 1 - (getEntityState(hass, fossilPercentageEntity) ?? 0) / 100 > 0;
+  return has;
 };
 
 export const getNonFossilSecondaryState = (hass: HomeAssistant, config: PowerFlowCardPlusConfig) =>
@@ -43,14 +34,18 @@ export const getNonFossilSecondaryState = (hass: HomeAssistant, config: PowerFlo
 
 export const getNonFossilState = (hass: HomeAssistant, config: PowerFlowCardPlusConfig) => {
   const nonFossil = config.entities.fossil_fuel_percentage;
+  const grid = config.entities.grid;
   const fossilPercentageEntity = nonFossil?.entity;
-  const gridFromGrid = getGridConsumptionState(hass, config);
+  const powerFromGrid = adjustZeroTolerance(getGridConsumptionState(hass, config), grid?.display_zero_tolerance);
 
   if (fossilPercentageEntity === undefined) return null;
 
-  if (gridFromGrid === null) return null;
+  if (powerFromGrid === null) return null;
 
   if (getNonFossilHas(hass, config) === false) return 0;
 
-  return gridFromGrid * 1 - (getEntityState(hass, fossilPercentageEntity) ?? 0) / 100;
+  const nonFossilDecimal = isEntityInverted(config, "fossil_fuel_percentage")
+    ? (getEntityState(hass, fossilPercentageEntity) ?? 0) / 100
+    : 1 - (getEntityState(hass, fossilPercentageEntity) ?? 0) / 100;
+  return powerFromGrid * nonFossilDecimal;
 };

--- a/src/style/all.ts
+++ b/src/style/all.ts
@@ -166,7 +166,7 @@ export const allDynamicStyles = (
   }
   main.style.setProperty(
     "--icon-non-fossil-color",
-    entities.fossil_fuel_percentage?.color_icon ? "var(--non-fossil-color)" : "var(--primary-text-color)" || "var(--non-fossil-color)"
+    entities.fossil_fuel_percentage?.color_icon ? "var(--non-fossil-color)" : "var(--primary-text-color)"
   );
   main.style.setProperty(
     "--text-non-fossil-color",

--- a/src/ui-editor/schema/fossil_fuel_percentage.ts
+++ b/src/ui-editor/schema/fossil_fuel_percentage.ts
@@ -19,6 +19,11 @@ const mainSchema = {
       },
     },
     {
+      name: "invert_state",
+      label: "Invert State",
+      selector: { boolean: {} },
+    },
+    {
       name: "color_value",
       label: "Color Value",
       selector: { boolean: {} },


### PR DESCRIPTION
This pull request refactors how the "non-fossil fuel" state and display logic are handled throughout the codebase. The main improvement is the addition of the 'Invert State' mode to Fossil Fuels so someone who has an entity with the percentage of grid renewables instead of the percentage of grid fossil fuels can still use that entity.

**Other changes:**
* Removed the `hasPercentage` property from the non-fossil fuel object and refactored all logic to use only the `has` property for determining non-fossil fuel availability since they both did the same thing.
* Simplified `src/states/raw/nonFossil.ts` and updated it to check the grid zero tolerance to determine whether to show or not (before the renewable circle would show even if the grid was showing 0W since its value was below the zero tolerance)
* Use all grid imports, instead of just the power that went to the home. Previously, if grid was only charging the battery, the renewable energy would be 0W, even if the grid was 100% renewable.