### PR TITLE
fix: Secondary Template for nonFossilFuel (Fixes #618)

### DIFF
--- a/src/components/non-fossil.ts
+++ b/src/components/non-fossil.ts
@@ -37,7 +37,7 @@ export const nonFossilElement = (
             }
           }}
         >
-          ${generalSecondarySpan(main.hass, main, config, templatesObj, nonFossil, "low-carbon")}
+          ${generalSecondarySpan(main.hass, main, config, templatesObj, nonFossil, "nonFossilFuel")}
           ${nonFossil.icon !== " " ? html` <ha-icon id="low-carbon-icon" .icon=${nonFossil.icon} />` : null}
           ${entities.fossil_fuel_percentage?.display_zero_state !== false ||
           (nonFossil.state.power || 0) > (entities.fossil_fuel_percentage?.display_zero_tolerance || 0)


### PR DESCRIPTION
The Template in nonFossilFuel Secondary was not displayed due to different naming.
This fixes Issue #618.
(Tested with v0.2.7)